### PR TITLE
Úprava historického žebříčku

### DIFF
--- a/statistiky.htm
+++ b/statistiky.htm
@@ -169,9 +169,9 @@
   </p>
   <p class="inf">
     <br />
-    Tzn. pokud budu první, získám 50 000*2 bodů, tedy 100 000 bodů do celkového skóre, do kterého se počítají  3 nejlepší dosažené výsledky. Pokud má hráč dvě
-    země, tak se  skóre počítá stejně jako u jiných, jen je každá země hodnocena jinak (jedna má menší a druhá větší váhu). Konkretní vzorec tedy vypadá
-    takto:((5*lepší_zem+2*horší_zem)/7).
+    Tzn. pokud budu první, získám 50 000*2 bodů, tedy 100 000 bodů do celkového skóre, do kterého se počítají 3 nejlepší dosažené výsledky. <br />
+    Pokud má hráč více zemí, se kterými opustil v jednom věku protekci, vezmou se dvě nejvýše umístěné, pro každou se spočítají body zvlášt a následně se
+    aplikuje vzorec pro výsledný bodový zisk ve tvaru ((5*lepší_zem+2*horší_zem)/7).
   </p>
   <p><strong>Duely:</strong> Můžete vyzvat libovolný počet zemí k duelu např. v prestiži, zkušenostech nasbíraných za věk apod. Cílová země ho musí přijmout. Poté můžete sledovat na grafu průběh tohoto duelu (jelikož se graf kreslí jednou denně, musíte počkat až bude dostatek dat pro vykreslení). Vyhlášené duely si může každý  prohlížet. Duel  může vyhlásit <strong>pouze <a href="prispevky.htm#GS2">GOLD</a>/<a href="prispevky.htm#GS4">PLATINUM</a> hráč</strong>, ale přijmout jej může kdokoli.</p>
   

--- a/statistiky.htm
+++ b/statistiky.htm
@@ -129,75 +129,50 @@
   <p><strong>Rekordy: </strong>V přehledu rekordů vidíte jmenovitě 10 nejlepších zemí v atributech jako je velikost území, <a href="zbozi.htm#Lid">počet obyvatel</a>, nejlepší producenty <a href="techno.htm#TUv">technologií</a>, <a href="zbozi.htm#Pen">peněz</a>, dílů v <a href="budovy.htm#Tov">továrnách</a>, <a href="valky.htm#Voj">vojáků</a>, <a href="zbozi.htm#JaE">jídla</a>, <a href="zbozi.htm#JaE">energie</a>, nejsilnější <a href="valky.htm#ROb">rozvědku</a>, počet <a href="valky.htm#Rnu">nukleárních raket</a>, <a href="valky.htm#UZk">nejzkušenější</a> armádu,   
      nejlepší <a href="valky.htm#GE3">generály</a>, <a href="techno.htm#NBS">nejvyšší budovu světa</a>  a nejdéle žijící obyvatele.  Aktualizuje se jednou za hodinu.</p>
   <p class="inf">Pokud nejste v rekordech ve výrobě dílu v továrnách, je to zřejmě tím, že vyrábíte <a href="valky.htm#Mech">mechy</a>. Ty mají ale odlišný bonus do výroby, proto je směrodatný údaj při výrobě tanků, stíhaček nebo bunkrů.</p>
-  <p><strong>Historické tabulky: </strong>Poměrně sledovaným aspektem je i historické 
-    pořadí, ve kterém si můžete prohlédnout, jak si který hráč vede v historii hry. V současnosti se body přidělují tak, že hráč dostane za své umístění body, ty se dále ještě vynásobí číslem, které je určeno jeho řádovým umístěním (např. zda byl v první stovce, druhé stovce hráčů atd.). Poté se sečtou body za 3 nejlepší výsledky a tím se určí výsledné pořadí.</p>
+  <p>
+    <strong>Historické tabulky: </strong>Poměrně sledovaným aspektem je i historické pořadí, ve kterém si můžete prohlédnout, jak si který hráč vede v historii
+    hry. V současnosti se body přidělují tak, že hráč dostane za své umístění body, ty se dále ještě vynásobí číslem, které je určeno jeho řádovým umístěním
+    (např. zda byl v první stovce, druhé stovce hráčů atd.). Poté se sečtou body za 3 nejlepší výsledky a tím se určí výsledné pořadí. Země, která neopustila
+    protekci, není započítána do vzorce pro výpočet dosažených bodů.
+  </p>
   <p class="inf">Konkrétně se to počítá následujícím způsobem: </p>
-  <p><span class="inf"> Maximum, kterého hráč může dosáhnout je  50 000 bodů. Tento počet bodů dostane  1. hráč, ostatní pak dostávají přímo úměrně méně. <br>
-  (např. ve věku vyšlo z  protekce 25 000 hráčů, tzn. za každé místo dolů je o 2 body méně -&gt; za 2.místo 49 998 bodů, 3.místo 49 996 bodů ...). Tento počet získaných bodů se vynásobí koeficientem dle tabulky.</span><br>
-</p>
-<br>
-  <table width="673" border="2" align="center" bordercolor="#333333" class=std>
-    <tr align="center">
-      <th width=113><div align="center">Umístění</div></th>
-      <th width=70><div align="center"><strong>1</strong></div></th>
-      <th width=70><div align="center">do 10</div></th>
-      <th width=70><div align="center">do 40 </div></th>
-      <th width=70><div align="center">do 100</div></th>
-      <th width=70><div align="center">do 200</div></th>
-      <th width=70><div align="center">do 400</div></th>
-      <th width=70><div align="center">do 700 </div></th>
-      <th width=70> do 1000</th>
-    </tr>
-    <tr align="center">
-      <th width=113>Koeficient</th>
-      <td  width=70><div align="center">2</div></td>
-      <td  width=70><div align="center">1,8</div></td>
-      <td  width=70><div align="center"><span class="styl1">1,6</span></div></td>
-      <td  width=70><div align="center">1,5</div></td>
-      <td  width=70><div align="center">1,4</div></td>
-      <td  width=70><div align="center">1,3</div></td>
-      <td  width=70><div align="center">1,2</div></td>
-      <td width=70><div align="center">1,1</div></td>
-    </tr>
-  </table>
-  <br>
-<!--    <font color=f59700>Parametry s koeficienty pro server GOLD WG:</font>
-  <table width="673" border="2" align="center" bordercolor="#333333" class=std style="color: rgb(245, 151, 0);" >
-    <tr align="center">
-      <th width=113><div align="center">Umístění</div></th>
-      <th width=70><div align="center"><strong>1</strong></div></th>
-      <th width=70><div align="center">do 10</div></th>
-      <th width=70><div align="center">do 40 </div></th>
-      <th width=70><div align="center">do 100</div></th>
-      <th width=70><div align="center">do 200</div></th>
-    </tr>
-    <tr align="center">
-      <th width=113>Koeficient</th>
-      <td  width=70><div align="center">2</div></td>
-      <td  width=70><div align="center">1,8</div></td>
-      <td  width=70><div align="center">1,6</span></div></td>
-      <td  width=70><div align="center">1,4</div></td>
-      <td  width=70><div align="center">1,2</div></td>
-    </tr>
-  </table> 
-  -->
-  <p><br>
-    <br>
-    <span class="inf">Tzn. pokud budu první, získám 50 000*2 bodů, tedy 100 000 bodů do celkového skóre, do kterého se počítají  3 nejlepší dosažené výsledky. Pokud má hráč dvě země, tak se  skóre počítá stejně jako u jiných, jen je každá země hodnocena jinak (jedna má menší a druhá větší váhu). Konkretní vzorec tedy vypadá takto:((5*lepší_zem+2*horší_zem)/7).</span></p>
-  <p>&nbsp; </p>
-  <!-------- STARY HODNOCENI -----------------------------------------------------
-  <p>Eviduje se  pořadí <strong>hráčů</strong> za všechny dosud odehrané věky, kdy je hráč na konci 
-    každého věku obodován podle svého umístění na jeho konci (vítěz má nejvíce bodů 
-    v závislosti na počtu zúčastněných hráčů, poslední hráč získává 0 bodů). Do bodování 
-    se Vám počítá pouze 5 nejlepších věků. Proto mají šanci na dobré umístění 
-    všichni, kteří hrají Webgame alespoň několik věků.</p>
-        -->
-    <!--    HISTORICKE PORADI ALIANCI
-  <p>V historickém pořadí <strong><a href="aliance.htm#Al">aliancí</a></strong> zase vidíte dlouhodobě nejlepší aliance ve Webgame.
-    Na konci věku vždy dostanou aliance body podle svého pořadí plus bonusové body 
-    za některé atributy. V hodnocení aliancí získávají body pouze nejlepší aliance (zhruba 
-    10-15 aliancí za každý věk). Body za všechny věky jsou sečteny a je sestaveno 
-    historické pořadí aliancí.</p>          -->
+  <p class="inf">
+    Maximum, kterého hráč může dosáhnout je  50 000 bodů. Tento počet bodů dostane  1. hráč, ostatní pak dostávají přímo úměrně méně. <br>
+    (např. ve věku vyšlo z  protekce 25 000 hráčů, tzn. za každé místo dolů je o 2 body méně -&gt; za 2.místo 49 998 bodů, 3.místo 49 996 bodů ...). Tento počet
+    získaných bodů se vynásobí koeficientem dle tabulky.
+  </p>
+    <br />
+    <table width="673" border="2" align="center" bordercolor="#333333" class=std>
+      <tr align="center">
+        <th width=113><div align="center">Umístění</div></th>
+        <th width=70><div align="center"><strong>1</strong></div></th>
+        <th width=70><div align="center">do 10</div></th>
+        <th width=70><div align="center">do 40 </div></th>
+        <th width=70><div align="center">do 100</div></th>
+        <th width=70><div align="center">do 200</div></th>
+        <th width=70><div align="center">do 400</div></th>
+        <th width=70><div align="center">do 700 </div></th>
+        <th width=70> do 1000</th>
+      </tr>
+      <tr align="center">
+        <th width=113>Koeficient</th>
+        <td  width=70><div align="center">2</div></td>
+        <td  width=70><div align="center">1,8</div></td>
+        <td  width=70><div align="center"><span class="styl1">1,6</span></div></td>
+        <td  width=70><div align="center">1,5</div></td>
+        <td  width=70><div align="center">1,4</div></td>
+        <td  width=70><div align="center">1,3</div></td>
+        <td  width=70><div align="center">1,2</div></td>
+        <td width=70><div align="center">1,1</div></td>
+      </tr>
+    </table>
+  </p>
+  <p class="inf">
+    <br />
+    Tzn. pokud budu první, získám 50 000*2 bodů, tedy 100 000 bodů do celkového skóre, do kterého se počítají  3 nejlepší dosažené výsledky. Pokud má hráč dvě
+    země, tak se  skóre počítá stejně jako u jiných, jen je každá země hodnocena jinak (jedna má menší a druhá větší váhu). Konkretní vzorec tedy vypadá
+    takto:((5*lepší_zem+2*horší_zem)/7).
+  </p>
   <p><strong>Duely:</strong> Můžete vyzvat libovolný počet zemí k duelu např. v prestiži, zkušenostech nasbíraných za věk apod. Cílová země ho musí přijmout. Poté můžete sledovat na grafu průběh tohoto duelu (jelikož se graf kreslí jednou denně, musíte počkat až bude dostatek dat pro vykreslení). Vyhlášené duely si může každý  prohlížet. Duel  může vyhlásit <strong>pouze <a href="prispevky.htm#GS2">GOLD</a>/<a href="prispevky.htm#GS4">PLATINUM</a> hráč</strong>, ale přijmout jej může kdokoli.</p>
   
   <!-- 	ŽEBŘÍČEK NOVÁČKŮ ----------


### PR DESCRIPTION
Potřeboval jsem do helpu zahrnout informaci o tom, že se do historického žebříčku nepočítá země, která nevyšla z protekce. Zároveň help obsahoval info, jak se počítají body pro hráče se 2 zeměmi, ale nikoli jak se počítají 3 a 4 země. Do úvahy se berou 2 nejvýše postavené, tak jsem to info tam zahrnul.

Odebral jsem rovnou zakomentované bloky pro GWG či staré počítaní a taky trochu upravil formátování odstavců, kterých jsem se dotýkal, abych se v tom vyznal. To odebrání zakomentovaného kodu je možná zbytečné, ale tak je to ted v gitu, takže když by někdy bylo nutné to vytáhnout, tak to jde vzít z tama přes git blame. :slightly_smiling_face: 

@stanislavkrasa :pray: 