### PR TITLE
Odstranění nepravdivé věty o simultánní půjčce

### DIFF
--- a/nabidkaleft.htm
+++ b/nabidkaleft.htm
@@ -86,7 +86,7 @@ function cls2(co){
     <td height=29 align="center" bgcolor="#8899cc"><font size=3 color="white"><b>Webgame.cz</b></font></td>
   </tr>
       <tr>
-        <td align="center" bgcolor="#8899cc"><font style="font-size:12px";>Aktualizace 29. 08. 2021</font>
+        <td align="center" bgcolor="#8899cc"><font style="font-size:12px";>Aktualizace 06. 09. 2021</font>
 <br>
 <font  class=nadpis> <a href="wghelp.zip"><i>Stáhnout (cca 2,5 MB)</i></a>
 </font></td></tr>

--- a/prispevky.htm
+++ b/prispevky.htm
@@ -179,7 +179,7 @@
     <tr>
       <td><center>GOLD půjčka + Simultánní půjčka</center></td>
       <td><a id="gold_pujcka"></a><center>Země si může půjčit malý finanční obnos od Světové banky a navíc v případě, že splatil min.
-      50% první půjčky může využít simultánní půjčku. Simultánně půjčovat si nelze posledních 5 dní věku.</center></td>
+      50% první půjčky může využít simultánní půjčku.</center></td>
       <td><center><b><font color="green">10</b></center></td>
       <td><center><a href="http://www.webgame.cz/wg/index.php?p=pracovna&s=wgplus-koupit&feature=simultaneous-loan">Koupit</a></center></td>
       <td><center><img src="http://icons.iconarchive.com/icons/cheezen/web-2/24/delete-icon.png"></center></td>


### PR DESCRIPTION
Simultánní půjčka lze vzít nejpozději 4 dny před koncem věku, nikoli 5. Celou větu jsem odstranil, protože tam není uvedeno ani limit dní pro normální půjčka. Rozepsaná je pár řádků výše ve 13.1.1.